### PR TITLE
include only necessary oc binaries

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -61,24 +61,9 @@ curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/c
     mv /opt/app-root/bin/oc /opt/app-root/bin/oc-3.11 && \
     rm ${APP_ROOT}/oc.tar.gz
 
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz && \
+curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/&& \
     tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
-    mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4.0 && \
-    rm ${APP_ROOT}/oc.tar.gz
-
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/linux/oc.tar.gz && \
-    tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
-    mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4.1 && \
-    rm ${APP_ROOT}/oc.tar.gz
-
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz && \
-    tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
-    mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4.2 && \
-    rm ${APP_ROOT}/oc.tar.gz
-
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/linux/oc.tar.gz && \
-    tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
-    mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4.3 && \
+    mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4 && \
     rm ${APP_ROOT}/oc.tar.gz
 
 ln -s /opt/app-root/bin/oc-wrapper.sh /opt/app-root/bin/oc

--- a/oc-wrapper.sh
+++ b/oc-wrapper.sh
@@ -1,26 +1,11 @@
 #!/bin/bash
 
 case $OC_VERSION in
-    3.10|3.10+|3.10.*)
-        OC_VERSION=3.10
-        ;;
-    3.11|3.11+|3.11.*)
-        OC_VERSION=3.11
-        ;;
-    4.0|4.0+|4.0.*)
-        OC_VERSION=4.0
-        ;;
-    4.1|4.1+|4.1.*)
-        OC_VERSION=4.1
-        ;;
-    4.2|4.2+|4.2.*)
-        OC_VERSION=4.2
-        ;;
-    4.3|4.3+|4.3.*)
-        OC_VERSION=4.3
+    4.*)
+        OC_VERSION=4
         ;;
     *)
-        OC_VERSION=4.1
+        OC_VERSION=3.11
         ;;
 esac
 


### PR DESCRIPTION
include only necessary oc binaries
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #5 

## This introduces a breaking change

- [x] No

## This Pull Request implements

Removed other oc-binary installations.

## Description

As we run our workloads on PSI infrastructure, we would be using either 3.11 or 4.3 =<.