### PR TITLE
update base image to v0.15.0 and add version file

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,8 +1,7 @@
 check:
-  - thoth-precommit
   - thoth-build
 build:
-  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.2"
+  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0"
   build-stratergy: "Source"
   registry: "quay.io"
   registry-org: "thoth-station"

--- a/thoth/s2i-minimal-notebook/__init__.py
+++ b/thoth/s2i-minimal-notebook/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# s2i-minimal-notebook
+# Copyright(C) 2019, 2020
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""S2I Minimal Notebook."""
+
+
+__name__ = "s2i-minimal-notebook"
+__version__ = "0.0.5"


### PR DESCRIPTION
update base image to v0.15.0 and add version file
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related to release of update base image s2i-thoth-ubi8-py36.

## This introduces a breaking change

- [x] No

## This Pull Request implements
- updated aicoe-ci config file to use  updated s2i-thoth-ubi8-py36 
- introduce a thoth/s2i-minimal-notebook/__init__.py  to allow kebechet to maintain release updates and changelogs.

## Description

kebechet updates semver version change to app.py,wsgi.py,__init__.py to reduce confusion , kept the __init__.py in thoth/s2i-minimal-notebook. Maintainer of s2i-minimal-notebook can now use issue template , like new-patch-release to have kebechet handle release with changelog.