### PR TITLE
Add support for cloning branch repo

### DIFF
--- a/builder/run
+++ b/builder/run
@@ -34,6 +34,13 @@ fi
 # Pre-clone repositories defined in JUPYTER_PRELOAD_REPOS
 if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then
     for repo in `echo ${JUPYTER_PRELOAD_REPOS} | tr ',' ' '`; do
+        # Check for the presence of "@branch" in the repo string
+        REPO_BRANCH=$(echo ${repo} | cut -s -d'@' -f2)
+        if [[ -n ${REPO_BRANCH} ]]; then
+          # Remove the branch from the repo string and convert REPO_BRANCH to git clone arg
+          repo=$(echo ${repo} | cut -d'@' -f1)
+          REPO_BRANCH="-b ${REPO_BRANCH}"
+        fi
         echo "Checking if repository $repo exists locally"
         REPO_DIR=$(basename ${repo})
         if [ -d "${REPO_DIR}" ]; then
@@ -41,7 +48,7 @@ if [ -n "${JUPYTER_PRELOAD_REPOS}" ]; then
             GIT_SSL_NO_VERIFY=true git pull --ff-only
             popd
         else
-            GIT_SSL_NO_VERIFY=true git clone ${repo} ${REPO_DIR}
+            GIT_SSL_NO_VERIFY=true git clone ${repo} ${REPO_DIR} ${REPO_BRANCH}
         fi
     done
 fi


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: #4 

## Description

Notebook pod env var "JUPYTER_PRELOAD_REPOS" can now specify a branch
based on format "https://<GIT_REPO_URL>#<GIT_BRANCH_NAME>"