### PR TITLE
Revert "exclude cached files created from the build process"

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -11,10 +11,6 @@ APP_ROOT=${APP_ROOT:-/opt/app-root/src}
 
 /usr/libexec/s2i/assemble
 
-# Remove the cached package dependencies files generated from s2i assemble script.
-rm -rf /tmp/Pipfile.lock
-rm -rf /tmp/requirements.txt
-
 ########################################################################
 # INFO: Install everything that's required for Jupyter notebooks here.
 ########################################################################


### PR DESCRIPTION
Reverts thoth-station/s2i-minimal-notebook#28
Related: https://github.com/thoth-station/s2i-thoth/pull/131
Related: https://github.com/thoth-station/micropipenv#adjusting-options-using-environment-variables
Related: https://github.com/thoth-station/s2i-minimal-notebook/pull/31
Related: https://github.com/thoth-station/s2i-minimal-notebook/issues/27