### PR TITLE
make webdav working again

### DIFF
--- a/gateway/server.js
+++ b/gateway/server.js
@@ -58,7 +58,7 @@ function install_routes(directory) {
 install_routes(path.join(__dirname, 'routes'));
 
 app.use(proxy(uri_root_path, {
-    target: 'http://127.0.0.1:8082',
+    target: 'http://127.0.0.1:8888',
     ws: true
 }));
 

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -13,6 +13,7 @@ fi
 
 cd /opt/app-root/gateway
 
-source scl_source enable rh-nodejs10
+# Don't stop on ubi8 wich don't use scl anymore
+source scl_source enable rh-nodejs10 || true
 
 exec npm start

--- a/supervisor/notebook.conf
+++ b/supervisor/notebook.conf
@@ -1,7 +1,7 @@
 [program:notebook]
 process_name=notebook
 command=start-notebook.sh
-environment=JUPYTER_NOTEBOOK_PORT="8082"
+environment=JUPYTER_NOTEBOOK_PORT="8888"
 stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
- fix notebook port
- don't use scl on ubi8

## Related Issues and Dependencies

legacy webdav shell script don't work on ubi8 source image

## This introduces a breaking change

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

If user enable JUPYTER_WEBDAV_ENABLE env var and JUPYTER_NOTEBOOK_PASSWORD, it will give access to /webdav url 
(with jupyter login and JUPYTER_NOTEBOOK_PASSWORD env var value).

JUPYTER_WEBDAV_ENABLE  could be set from kfdef kustomization

## Description

- notebook port is now 8888 (and not 8082)
- on ubi8 image, we don't have scl anymore, so ignore it in start-gateway.sh script
