### PR TITLE
Images optimization

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -21,11 +21,11 @@ rm -rf /tmp/requirements.txt
 
 # Install pipenv for jupyter-nbrequirements to use
 # TODO: This should be removed once nbrequirements can use Thoth + micropipenv only
-pip install pipenv==2020.11.15
+pip install --no-cache-dir --disable-pip-version-check pipenv==2020.11.15
 
 # Install mod_wsgi for use in optional webdav support.
 
-pip install 'mod_wsgi==4.6.8'
+pip install --no-cache-dir --disable-pip-version-check 'mod_wsgi==4.6.8'
 
 # Install base packages needed for running Jupyter Notebooks.
 
@@ -108,7 +108,7 @@ jupyter nbextension enable  --sys-prefix publish
 
 # Enable the extensions configurator
 
-pip install -U jupyter_nbextensions_configurator
+pip install --no-cache-dir -U jupyter_nbextensions_configurator
 
 jupyter nbextensions_configurator enable --sys-prefix
 
@@ -128,6 +128,15 @@ fi
 # produced to run further S2I builds
 
 (shopt -s dotglob ; rm -rf ${APP_ROOT}/src/*)
+
+# Final cleanup
+
+jupyter lab clean
+
+npm cache clean --force
+
+rm -rf $HOME/.cache/yarn
+rm -rf $HOME/.node-gyp
 
 # Fixup permissions on directories and files.
 

--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -10,7 +10,7 @@ runtime_environments:
       version: "8"
     python_version: "3.6"
     recommendation_type: latest
-    base_image: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0
+    base_image: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0
 
   - name: python38
     operating_system:
@@ -18,7 +18,7 @@ runtime_environments:
       version: "8"
     python_version: "3.8"
     recommendation_type: latest
-    base_image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0
+    base_image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0
 
   - name: f34-python39
     operating_system:
@@ -26,7 +26,7 @@ runtime_environments:
       version: "34"
     python_version: "3.9"
     recommendation_type: latest
-    base_image: quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1
+    base_image: quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0
 
 managers:
   - name: update

--- a/overlays/f34-python39/Dockerfile
+++ b/overlays/f34-python39/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1
+FROM quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0
 LABEL name="s2i-minimal-notebook:latest" \
       summary="Minimal Jupyter Notebook Source-to-Image for Python 3.9 applications." \
       description="Notebook image based on Source-to-Image.These images can be used in OpenDatahub JupterHub." \
@@ -9,7 +9,7 @@ LABEL name="s2i-minimal-notebook:latest" \
       authoritative-source-url="https://quay.io/thoth-station/s2i-minimal-f34-py39-notebook" \
       io.openshift.s2i.build.commit.ref="master" \
       io.openshift.s2i.build.source-location="https://github/thoth-station/s2i-minimal-notebook" \
-      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1"
+      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0"
 
 ENV JUPYTER_ENABLE_LAB="1" \
     ENABLE_MICROPIPENV="1" \
@@ -26,7 +26,9 @@ USER root
 # Upgrade NodeJS > 12.0
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -  && \
   yum remove -y nodejs && \
-  yum install -y nodejs
+  yum install -y nodejs && \
+  yum -y clean all && \
+  rm -rf /var/cache/dnf
 
 # Copying in override assemble/run scripts
 COPY .s2i/bin /tmp/scripts

--- a/overlays/python36/Dockerfile
+++ b/overlays/python36/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0
+FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0
 LABEL name="s2i-minimal-notebook:latest" \
       summary="Minimal Jupyter Notebook Source-to-Image for Python 3.6 applications." \
       description="Notebook image based on Source-to-Image.These images can be used in OpenDatahub JupterHub." \
@@ -9,7 +9,7 @@ LABEL name="s2i-minimal-notebook:latest" \
       authoritative-source-url="https://quay.io/thoth-station/s2i-minimal-notebook" \
       io.openshift.s2i.build.commit.ref="master" \
       io.openshift.s2i.build.source-location="https://github/thoth-station/s2i-minimal-notebook" \
-      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0"
+      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0"
 
 ENV JUPYTER_ENABLE_LAB="1" \
     ENABLE_MICROPIPENV="1" \
@@ -26,7 +26,9 @@ USER root
 # Upgrade NodeJS > 12.0
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -  && \
   yum remove -y nodejs && \
-  yum install -y nodejs
+  yum install -y nodejs && \
+  yum -y clean all && \
+  rm -rf /var/cache/dnf
 
 # Copying in override assemble/run scripts
 COPY .s2i/bin /tmp/scripts

--- a/overlays/python38/Dockerfile
+++ b/overlays/python38/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.29.0
+FROM quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0
 LABEL name="s2i-minimal-notebook:latest" \
       summary="Minimal Jupyter Notebook Source-to-Image for Python 3.8 applications." \
       description="Notebook image based on Source-to-Image.These images can be used in OpenDatahub JupterHub." \
@@ -9,7 +9,7 @@ LABEL name="s2i-minimal-notebook:latest" \
       authoritative-source-url="https://quay.io/thoth-station/s2i-minimal-py38-notebook" \
       io.openshift.s2i.build.commit.ref="master" \
       io.openshift.s2i.build.source-location="https://github/thoth-station/s2i-minimal-notebook" \
-      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0"
+      io.openshift.s2i.build.image="quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0"
 
 ENV JUPYTER_ENABLE_LAB="1" \
     ENABLE_MICROPIPENV="1" \
@@ -26,7 +26,9 @@ USER root
 # Upgrade NodeJS > 12.0
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -  && \
   yum remove -y nodejs && \
-  yum install -y nodejs
+  yum install -y nodejs && \
+  yum -y clean all && \
+  rm -rf /var/cache/dnf
 
 # Copying in override assemble/run scripts
 COPY .s2i/bin /tmp/scripts


### PR DESCRIPTION
Follow-up to the first pass of image optimization done on s2i-thoth
- update base images with latest optimized builds (0.32.0)
- adding of jupyterlab build cleanup to assemble
- pip no-cache-dir added to assemble
- disable pip version check added to assemble
- dnf cache cleanup in dockerfiles

Optimisation results:
s2i-minimal-f34-py39-notebook:old_image 2.63GB
s2i-minimal-f34-py39-notebook:new_image 2.05GB

s2i-minimal-py38-notebook:old_image 2.07GB
s2i-minimal-py38-notebook:new_image 1.95GB

s2i-minimal-py36-notebook:old_image 1.96GB
s2i-minimal-py36-notebook:new_image 1.88GB

NOTE: optimisation is even better than those figures as base images had increased size from 0.26/0.28->0.32



