### PR TITLE
Readme fix and mod_wsgi update

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -25,7 +25,7 @@ pip install --no-cache-dir --disable-pip-version-check pipenv==2020.11.15
 
 # Install mod_wsgi for use in optional webdav support.
 
-pip install --no-cache-dir --disable-pip-version-check 'mod_wsgi==4.6.8'
+pip install --no-cache-dir --disable-pip-version-check 'mod_wsgi==4.9.2'
 
 # Install base packages needed for running Jupyter Notebooks.
 

--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ Instead of using the pre-built version of the minimal notebook, you can build th
 - Build python38: From the overlay/python38 by setting the environment variable `THAMOS_RUNTIME_ENVIRONMENT="python38"` in the Dockerfile
 
   ```bash
-  podman build -t s2i-minimal-py38-notebook -f overlays/python38/Dockerfile
+  podman build -t s2i-minimal-py38-notebook -f overlays/python38/Dockerfile .
   ```


### PR DESCRIPTION
## Related Issues and Dependencies
Issue #535 
…

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

- Added a (.) to python38 image build command in README.md, it won't build without it
- Bumped mod_wsgi version to last stable for F35 compatibility

## Description

- There is a typo in bash command for Python 3.8 image build
- Currently used mod_wsgi version has known issue with F35. The version 4.9 and above are tested to work correctly in F35

